### PR TITLE
feat: respect DOKKU_LIB_HOST_ROOT for mounted data volumes

### DIFF
--- a/config
+++ b/config
@@ -3,7 +3,8 @@ _DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export MEILISEARCH_IMAGE=${MEILISEARCH_IMAGE:="$(awk -F '[ :]' '{print $2}' "${_DIR}/Dockerfile")"}
 export MEILISEARCH_IMAGE_VERSION=${MEILISEARCH_IMAGE_VERSION:="$(awk -F '[ :]' '{print $3}' "${_DIR}/Dockerfile")"}
 export MEILISEARCH_ROOT=${MEILISEARCH_ROOT:="$DOKKU_LIB_ROOT/services/meilisearch"}
-export MEILISEARCH_HOST_ROOT=${MEILISEARCH_HOST_ROOT:=$MEILISEARCH_ROOT}
+export DOKKU_LIB_HOST_ROOT=${DOKKU_LIB_HOST_ROOT:=$DOKKU_LIB_ROOT}
+export MEILISEARCH_HOST_ROOT=${MEILISEARCH_HOST_ROOT:="$DOKKU_LIB_HOST_ROOT/services/meilisearch"}
 
 export PLUGIN_UNIMPLEMENTED_SUBCOMMANDS=("backup" "backup-auth" "backup-deauth" "backup-schedule" "backup-schedule-cat" "backup-set-encryption" "backup-unschedule" "backup-unset-encryption" "clone" "connect" "export" "import")
 export PLUGIN_COMMAND_PREFIX="meilisearch"


### PR DESCRIPTION
This change allows folks to change where dokku mounts data from for all official plugins, removing the need to specify the configuration on a one-off basis.

Refs dokku/dokku#5468