### PR TITLE
feat: Separating master key from DSN

### DIFF
--- a/common-functions
+++ b/common-functions
@@ -597,6 +597,8 @@ service_link() {
   declare SERVICE="$1" APP="$2"
   update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
+  local SERVICE_URL_SAFE=$(service_url_safe "$SERVICE")
+  local PASSWORD=$(service_password "$SERVICE")
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local SERVICE_ROOT="$PLUGIN_DATA_ROOT/$SERVICE"
   local EXISTING_CONFIG=$(config_all "$APP")
@@ -635,7 +637,12 @@ service_link() {
     config_set --no-restart "$APP" "${ALIAS}_URL=$SERVICE_URL"
     dokku_log_verbose "Skipping restart of linked app"
   else
-    config_set "$APP" "${ALIAS}_URL=$SERVICE_URL"
+    if [[ "$SERVICE_UNIFIED" == "true"]]; then
+      config_set "$APP" "${ALIAS}_URL=$SERVICE_URL"
+    else
+      config_set "$APP" "${ALIAS}_URL=$SERVICE_URL_SAFE"
+      config_set "$APP" "${ALIAS}_MASTER_KEY=$PASSWORD"
+    fi
   fi
   plugn trigger service-action post-link-complete "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "$APP"
 }
@@ -720,6 +727,7 @@ service_parse_args() {
       "--post-create-network") set -- "$@" "-P" ;;
       "--post-start-network") set -- "$@" "-S" ;;
       "--querystring") set -- "$@" "-q" ;;
+      "--unified") set -- "$@" "-U" ;;
       "--restart-apps") set -- "$@" "-R" ;;
       "--root-password") set -- "$@" "-r" ;;
       "--shm-size") set -- "$@" "-s" ;;
@@ -767,6 +775,9 @@ service_parse_args() {
         ;;
       q)
         export SERVICE_QUERYSTRING=${OPTARG#"?"}
+        ;;
+      U)
+        export SERVICE_UNIFIED=false
         ;;
       R)
         export SERVICE_RESTART_APPS=$OPTARG

--- a/common-functions
+++ b/common-functions
@@ -969,10 +969,12 @@ service_unlink() {
   declare SERVICE="$1" APP="$2"
   update_plugin_scheme_for_app "$APP"
   local SERVICE_URL=$(service_url "$SERVICE")
+  local SERVICE_URL_SAFE=$(service_url_safe "$SERVICE")
+  local PASSWORD=$(service_password "$SERVICE")
   local SERVICE_NAME="$(get_service_name "$SERVICE")"
   local EXISTING_CONFIG=$(config_all "$APP")
   local SERVICE_DNS_HOSTNAME=$(service_dns_hostname "$SERVICE")
-  local LINK=($(echo "$EXISTING_CONFIG" | grep "$SERVICE_URL" | cut -d: -f1)) || true
+  local LINK=($(echo "$EXISTING_CONFIG" | grep "$SERVICE_URL\|$SERVICE_URL_SAFE\|$PASSWORD" | cut -d: -f1)) || true
 
   plugn trigger service-action pre-unlink "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "$APP"
   remove_from_links_file "$SERVICE" "$APP"

--- a/common-functions
+++ b/common-functions
@@ -782,7 +782,7 @@ service_parse_args() {
         export SERVICE_QUERYSTRING=${OPTARG#"?"}
         ;;
       U)
-        export SERVICE_UNIFIED=$OPTARG
+        export SERVICE_UNIFIED=${OPTARG:-true}
         ;;
       R)
         export SERVICE_RESTART_APPS=$OPTARG

--- a/common-functions
+++ b/common-functions
@@ -637,7 +637,7 @@ service_link() {
     config_set --no-restart "$APP" "${ALIAS}_URL=$SERVICE_URL"
     dokku_log_verbose "Skipping restart of linked app"
   else
-    if [[ "$SERVICE_UNIFIED" == "true"]]; then
+    if [[ "$SERVICE_UNIFIED" == "true" ]]; then
       config_set "$APP" "${ALIAS}_URL=$SERVICE_URL"
     else
       config_set "$APP" "${ALIAS}_URL=$SERVICE_URL_SAFE"

--- a/common-functions
+++ b/common-functions
@@ -634,7 +634,13 @@ service_link() {
   [[ -n "$SERVICE_QUERYSTRING" ]] && SERVICE_URL="${SERVICE_URL}?${SERVICE_QUERYSTRING}"
   plugn trigger service-action post-link "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "$APP"
   if [[ "$DOKKU_GLOBAL_FLAGS" == *"--no-restart"* ]] || [[ "$SERVICE_RESTART_APPS" == "false" ]]; then
-    config_set --no-restart "$APP" "${ALIAS}_URL=$SERVICE_URL"
+
+    if [[ "$SERVICE_UNIFIED" == "true" ]]; then
+      config_set --no-restart "$APP" "${ALIAS}_URL=$SERVICE_URL"
+    else
+      config_set --no-restart "$APP" "${ALIAS}_URL=$SERVICE_URL_SAFE" "${ALIAS}_MASTER_KEY=$PASSWORD"
+    fi
+
     dokku_log_verbose "Skipping restart of linked app"
   else
     if [[ "$SERVICE_UNIFIED" == "true" ]]; then
@@ -776,7 +782,7 @@ service_parse_args() {
         export SERVICE_QUERYSTRING=${OPTARG#"?"}
         ;;
       U)
-        export SERVICE_UNIFIED=false
+        export SERVICE_UNIFIED=$OPTARG
         ;;
       R)
         export SERVICE_RESTART_APPS=$OPTARG

--- a/common-functions
+++ b/common-functions
@@ -640,8 +640,7 @@ service_link() {
     if [[ "$SERVICE_UNIFIED" == "true" ]]; then
       config_set "$APP" "${ALIAS}_URL=$SERVICE_URL"
     else
-      config_set "$APP" "${ALIAS}_URL=$SERVICE_URL_SAFE"
-      config_set "$APP" "${ALIAS}_MASTER_KEY=$PASSWORD"
+      config_set "$APP" "${ALIAS}_URL=$SERVICE_URL_SAFE" "${ALIAS}_MASTER_KEY=$PASSWORD"
     fi
   fi
   plugn trigger service-action post-link-complete "$PLUGIN_COMMAND_PREFIX" "$SERVICE" "$APP"
@@ -737,7 +736,7 @@ service_parse_args() {
   done
 
   OPTIND=1
-  while getopts "na:c:C:d:i:I:m:n:N:p:P:q:R:r:s:S:u:" opt; do
+  while getopts "na:c:C:d:i:I:m:n:N:p:P:q:U:R:r:s:S:u:" opt; do
     case "$opt" in
       a)
         SERVICE_ALIAS="${OPTARG^^}"

--- a/functions
+++ b/functions
@@ -214,3 +214,12 @@ service_url() {
   local PASSWORD="$(service_password "$SERVICE")"
   echo "$PLUGIN_SCHEME://:$PASSWORD@$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}"
 }
+
+service_url_safe() {
+  local SERVICE="$1"
+  local SERVICE_DNS_HOSTNAME="$(service_dns_hostname "$SERVICE")"
+  local DATABASE_NAME="$(get_database_name "$SERVICE")"
+  local PASSWORD="$(service_password "$SERVICE")"
+  echo "$PLUGIN_SCHEME://$SERVICE_DNS_HOSTNAME:${PLUGIN_DATASTORE_PORTS[0]}"
+}
+

--- a/tests/service_link.bats
+++ b/tests/service_link.bats
@@ -67,6 +67,22 @@ teardown() {
   dokku "$PLUGIN_COMMAND_PREFIX:unlink" ls my-app
 }
 
+@test "($PLUGIN_COMMAND_PREFIX:link) exports MEILISEARCH_URL and MEILISEARCH_MASTER_KEY to app" {
+  run dokku "$PLUGIN_COMMAND_PREFIX:link" ls my-app -U false
+  echo "output: $output"
+  echo "status: $status"
+  url=$(dokku config:get my-app MEILISEARCH_URL)
+  password="$(sudo cat "$PLUGIN_DATA_ROOT/ls/PASSWORD")"
+
+  assert_contains "$url" "http://dokku-meilisearch-ls:7700"
+  assert_success
+
+  assert_contains "${lines[*]}" "MEILISEARCH_MASTER_KEY"
+  assert_success
+
+  dokku "$PLUGIN_COMMAND_PREFIX:unlink" ls my-app
+}
+
 @test "($PLUGIN_COMMAND_PREFIX:link) generates an alternate config url when MEILISEARCH_URL already in use" {
   dokku config:set my-app MEILISEARCH_URL=http://user:pass@host:7700/db
   dokku "$PLUGIN_COMMAND_PREFIX:link" ls my-app


### PR DESCRIPTION
This change separates the master key from the DSN and sets it as $ALIAS_MASTER_KEY env var to the linked app, and leaves the $ALIAS_URL clean from credentials.

This is helping for tools like fetch to be able to call meilisearch endpoints without credential issues. Currently exposing credentials on URL blocks the HTTP operations on feth calls.

Based on the result of this PR, I will work on the documentation